### PR TITLE
Issue #6 - Collect audible/muted tab properties

### DIFF
--- a/src/lib/background/index.js
+++ b/src/lib/background/index.js
@@ -67,8 +67,10 @@ function refreshTabStates(onEach)
       }
 
       record(tab.id, "state", {
+        audible: tab.audible,
         incognito: tab.incognito,
         index: tab.index,
+        muted: !!tab.mutedInfo && tab.mutedInfo.muted,
         selected: tab.active,
         title: tab.title,
         url,
@@ -129,6 +131,16 @@ function onTabCreated(tab)
 
 function onTabUpdated(tabId, info)
 {
+  if ("audible" in info)
+  {
+    record(tabId, "audible", info.audible);
+  }
+
+  if ("mutedInfo" in info)
+  {
+    record(tabId, "muted", info.mutedInfo.muted);
+  }
+
   if ("url" in info)
   {
     let url;

--- a/test/tests/collection.js
+++ b/test/tests/collection.js
@@ -79,8 +79,10 @@ describe("Test background page data collection", () =>
         2,
         "state",
         {
+          audible: false,
           incognito: false,
           index: 1,
+          muted: true,
           selected: false,
           title: "BAR",
           url: "http://bar.com/",
@@ -173,6 +175,15 @@ describe("Test background page data collection", () =>
 
     expecting.push([2, "url", "http://baz.com/"]);
     chrome.tabs.onUpdated.trigger(2, {url: "http://baz.com"});
+
+    expecting.push([2, "title", "foo"]);
+    chrome.tabs.onUpdated.trigger(2, {title: "foo"});
+
+    expecting.push([2, "audible", true]);
+    chrome.tabs.onUpdated.trigger(2, {audible: true});
+
+    expecting.push([2, "muted", true]);
+    chrome.tabs.onUpdated.trigger(2, {mutedInfo: {muted: true}});
 
     expecting.push([1, "removed", null]);
     chrome.tabs.onRemoved.trigger(1, null);


### PR DESCRIPTION
This PR contains the following changes:
- Added "audible" and "muted" properties to "state" event
- Added "audible" and "muted" events
- Updated tests