### PR TITLE
Issue #23 - Stopped requiring active subscription for extension to be active

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -310,7 +310,7 @@
     "message": "Choose subscription"
   },
   "flattr_subscription_message": {
-    "message": "Please choose and activate your subscription to flattr creators."
+    "message": "Keep in mind that without an active subscription, your favorite creators won't receive any money from you. Any flattrs made without an active subscription will not be converted into money."
   },
   "flattr_subscription_title": {
     "message": "No subscription active"

--- a/src/lib/background/icon/index.js
+++ b/src/lib/background/icon/index.js
@@ -87,19 +87,11 @@ function updateIcon(tabId)
     state: "disabled"
   };
 
-  Promise.all([account.hasSubscription(), account.isAuthenticated()])
-    .then(([hasSubscription, isAuthenticated]) =>
+  account.isAuthenticated()
+    .then((isAuthenticated) =>
     {
       if (!isAuthenticated)
       {
-        setIconState(tabIcon);
-        return;
-      }
-
-      if (!hasSubscription)
-      {
-        tabIcon.state = "error";
-        tabIcon.text = "!";
         setIconState(tabIcon);
         return;
       }
@@ -205,7 +197,6 @@ on("flattr-added", ({flattr}) => onStateChanged(flattr));
 on("flattrs-removed", onStateChanged);
 on("status-changed", onStateChanged);
 on("authentication-changed", () => onStateChanged({}));
-on("subscription-changed", () => onStateChanged({}));
 
 on("notification-changed", ({notification, tabId}) =>
 {

--- a/src/lib/background/index.js
+++ b/src/lib/background/index.js
@@ -233,5 +233,4 @@ on("authentication-changed", (isAuthenticated) =>
   });
   refreshTabStates();
 });
-on("subscription-changed", () => refreshTabStates());
 on("reset", () => refreshTabStates());

--- a/src/lib/background/server/api.js
+++ b/src/lib/background/server/api.js
@@ -13,12 +13,9 @@ function send({account, flattrs})
   if (flattrs.length < 1)
     return Promise.resolve({ok: true});
 
-  let {subscription, token} = account;
+  let {token} = account;
   if (!token.accessToken)
     return Promise.resolve({ok: false, status: 401});
-
-  if (!subscription.active)
-    return Promise.resolve({ok: false, status: 402});
 
   return fetch(
     `${API_BASE}/rest/v2/flattr/bulk`,

--- a/src/lib/common/account.js
+++ b/src/lib/common/account.js
@@ -32,7 +32,7 @@ function hasSubscription()
 exports.hasSubscription = hasSubscription;
 
 /**
- * Determine whether user account is ready and extension should be active
+ * Determine whether extension should be active
  * @return {Promise<boolean>}
  */
 exports.isActive = isAuthenticated;

--- a/src/lib/common/account.js
+++ b/src/lib/common/account.js
@@ -32,15 +32,10 @@ function hasSubscription()
 exports.hasSubscription = hasSubscription;
 
 /**
- * Determine whether user account is complete and extension should be active
+ * Determine whether user account is ready and extension should be active
  * @return {Promise<boolean>}
  */
-function isActive()
-{
-  return Promise.all([isAuthenticated(), hasSubscription()])
-    .then(([authenticated, subscribed]) => authenticated && subscribed);
-}
-exports.isActive = isActive;
+exports.isActive = isAuthenticated;
 
 /**
  * Determine whether user linked Flattr account

--- a/src/lib/ui/components/flattr-popup.js
+++ b/src/lib/ui/components/flattr-popup.js
@@ -67,7 +67,7 @@ class FlattrPopup extends VirtualElement
 
     // Don't show notification if extension is inactive
     let notificationId = null;
-    if (this._authenticated && this._subscription)
+    if (this._authenticated)
     {
       notificationId = this._notification;
     }
@@ -89,18 +89,17 @@ class FlattrPopup extends VirtualElement
     }
     else
     {
+      let messageBox = h("popup-beta.message-box");
       if (!this._subscription)
       {
-        body.push(h("div.message", v("subscribe-message")));
+        messageBox = h("div.message-box", v("subscribe-message"));
       }
-      else
-      {
-        body.push(
-          h("div#notification"),
-          h("flattr-control"),
-          h("popup-beta")
-        );
-      }
+
+      body.push(
+        h("div#notification"),
+        h("flattr-control"),
+        messageBox
+      );
 
       footer.push(
         h(

--- a/src/lib/ui/components/virtual/subscribe-message.js
+++ b/src/lib/ui/components/virtual/subscribe-message.js
@@ -12,7 +12,7 @@ const i18n = require("../../i18n");
 function create()
 {
   return [
-    h("h3", i18n.get("flattr_subscription_title")),
+    h("h2", i18n.get("flattr_subscription_title")),
     h("p", i18n.get("flattr_subscription_message")),
     h(
       "a.button.primary",

--- a/src/ui/css/popup-message-box.css
+++ b/src/ui/css/popup-message-box.css
@@ -6,7 +6,7 @@
   font-style: normal;
 }
 
-popup-beta
+.message-box
 {
   display: block;
   padding: 10px 15px;
@@ -17,20 +17,24 @@ popup-beta
   transition-duration: 200ms;
 }
 
-popup-beta > h2
+.message-box > h2
 {
   display: flex;
   margin: 0;
   font-size: 1.1em;
+}
+
+.message-box > h2 > *
+{
   cursor: pointer;
 }
 
-popup-beta > h2 > span
+.message-box > h2 > span
 {
   flex-grow: 1;
 }
 
-popup-beta > h2 > button
+.message-box > h2 > button
 {
   border: none;
   font-weight: inherit;
@@ -41,39 +45,39 @@ popup-beta > h2 > button
   transition-duration: 200ms;
 }
 
-popup-beta > h2 > button::after
+.message-box > h2 > button::after
 {
   font-family: flattr-icons;
   content: "\e60d"; /* icon-caret */
 }
 
-popup-beta > h2:hover > button
+.message-box > h2:hover > button
 {
   color: #1AA3D4;;
 }
 
-popup-beta[collapsed]
+.message-box[collapsed]
 {
   border-color: #F2F2F2;
   background-color: #F2F2F2;
 }
 
-popup-beta:not([collapsed]) > h2 > button
+.message-box:not([collapsed]) > h2 > button
 {
   transform: scaleY(-1);
 }
 
-popup-beta[collapsed] > p
+.message-box[collapsed] > p
 {
   display: none;
 }
 
-popup-beta > p:last-child
+.message-box > p:last-child
 {
   margin-bottom: 0;
 }
 
-popup-beta a
+.message-box a
 {
   text-decoration: underline;
 }

--- a/src/ui/popup.html
+++ b/src/ui/popup.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8"/>
     <link rel="stylesheet" type="text/css" href="css/common.css"/>
     <link rel="stylesheet" type="text/css" href="css/input-toggle.css"/>
-    <link rel="stylesheet" type="text/css" href="css/popup-beta.css"/>
+    <link rel="stylesheet" type="text/css" href="css/popup-message-box.css"/>
     <link rel="stylesheet" type="text/css" href="css/popup-flattr-control.css"/>
     <link rel="stylesheet" type="text/css" href="css/popup.css"/>
     <script src="js/webcomponents-lite.js" defer></script>

--- a/test/tests/account.js
+++ b/test/tests/account.js
@@ -293,7 +293,7 @@ describe("Test account management", () =>
     });
   });
 
-  it("Should not submit anything without active subscription", () =>
+  it("Should submit Flattrs even without active subscription", () =>
   {
     let fetchCount = 0;
 
@@ -313,8 +313,8 @@ describe("Test account management", () =>
       yield account.setToken(mockToken);
 
       let {status} = yield serverApi.sendFlattrs({flattrs: [{url: "foo"}]});
-      expect(fetchCount).to.equal(0);
-      expect(status).to.equal(402);
+      expect(fetchCount).to.equal(1);
+      expect(status).to.equal(200);
     });
   });
 

--- a/test/tests/collection.js
+++ b/test/tests/collection.js
@@ -219,9 +219,9 @@ describe("Test background page data collection", () =>
   {
     let expecting = {
       "authenticated": 1,
-      "selected-initial": 4,
+      "selected-initial": 3,
       "started": 1,
-      "state": 8
+      "state": 6
     };
 
     chrome.runtime.id = "extensionid";

--- a/test/tests/icon.js
+++ b/test/tests/icon.js
@@ -129,8 +129,8 @@ describe("Test browserAction icon", () =>
 
   it("Enabled", () => run("enabled", {}, {}));
 
-  it("Error (no subscription)", () =>
-      run("error", {text: "!"}, {subscribed: false}));
+  it("Enabled (no subscription)", () =>
+      run("enabled", {}, {subscribed: false}));
 
   it("Notification (info)", () =>
   {


### PR DESCRIPTION
This PR contains the following changes:
- Stopped considering subscription state for determining whether extension should be active
  - Stopped considering subscription state in `account.isActive()`
  - Stopped considering subscription state when submitting flattrs
  - Removed "subscription-changed" listener in lib/background/index.js because we no longer need to reinitialize the tab states when the subscription state changes
- Updated subscription message
  - Moved message in place of "beta" section of icon popup
  - Renamed "popup-beta" styles to "message-box" so that we can reuse them for the message
  - Updated message text
- Removed error icon
- Adapted tests

PS: This change made it obvious that in some cases we use `isAuthenticated()` and listen to "authenticated-changed" even when we meant to react to when the extension becomes active/inactive. However, I decided not to include this change in here, since it's not strictly required for this change. We'll still need to fix it though.