### PR TITLE
Issue #21 - Added fallback ability to status resolver logic

### DIFF
--- a/src/data/domains.json
+++ b/src/data/domains.json
@@ -19,12 +19,12 @@
   ],
   "org": {
     "chromium": {
-      "": 1,
+      "*": 1,
       "bugs": 3,
       "cs": 3
     },
     "xenite": {
-      "": 1,
+      "*": 1,
       "shop": 3
     }
   },
@@ -2125,7 +2125,7 @@
       "4xauto": 1,
       "4xbxb": 1,
       "500px": {
-        "": 1,
+        "*": 1,
         "/": 3,
         "/classes": 3,
         "/editors": 3,
@@ -8806,9 +8806,8 @@
       "flexonline": 1,
       "flickeringmyth": 1,
       "flickr": {
-        "": 1,
+        "*": 1,
         "www": {
-          "": 1,
           "/": 3,
           "/cameras": 3,
           "/commons": 3,
@@ -9140,9 +9139,8 @@
       "freedombankwv": 3,
       "freedsound": 1,
       "freefavicon": {
-        "": 1,
+        "*": 1,
         "www": {
-          "": 1,
           "/iconmaker": 3
         }
       },
@@ -9796,7 +9794,7 @@
       "gistmania": 1,
       "gistreel": 1,
       "github": {
-        "": 1,
+        "*": 1,
         "/": 3,
         "/issues": 3,
         "/marketplace": 3,
@@ -12263,7 +12261,7 @@
       "kaufmanherald": 1,
       "kawarthanow": 1,
       "kazunekoyama": {
-        "": 1,
+        "*": 1,
         "/": 3,
         "/about": 3,
         "/c112": 3,
@@ -14019,7 +14017,7 @@
       "mediosordo": 1,
       "mediotiempo": 1,
       "medium": {
-        "": 1,
+        "*": 1,
         "/": 3,
         "/about": 3,
         "/browse": 3,
@@ -19247,7 +19245,7 @@
       "soundandvision": 1,
       "soundclick": 1,
       "soundcloud": {
-        "": 1,
+        "*": 1,
         "/": 3,
         "/charts": 3,
         "/jobs": 3,
@@ -22221,7 +22219,7 @@
       "twitrand": 1,
       "twitrcovers": 1,
       "twitter": {
-        "": 1,
+        "*": 1,
         "/": 3,
         "/following": 3,
         "/hashtag": 3,
@@ -22737,7 +22735,7 @@
       "villeplattetoday": 1,
       "villiscareview": 1,
       "vimeo": {
-        "": 1,
+        "*": 1,
         "/": 3,
         "/business": 3,
         "/create": 3,
@@ -23712,7 +23710,7 @@
       "wordnerdmemoir": 1,
       "wordpandit": 1,
       "wordpress": {
-        "": 1,
+        "*": 1,
         "/": 3,
         "/about": 3,
         "/features": 3,
@@ -24127,9 +24125,8 @@
       "youthkiawaaz": 1,
       "youthvocal": 1,
       "youtube": {
-        "": 1,
+        "*": 1,
         "www": {
-          "": 1,
           "/": 3,
           "/account": 3,
           "/account_notifications": 3,
@@ -24226,7 +24223,7 @@
       "zeemasti": 1,
       "zehabesha": 1,
       "zelaphas": {
-        "": 1,
+        "*": 1,
         "/": 3,
         "/commission": 3,
         "/contact": 3,
@@ -25618,7 +25615,7 @@
       "kalenderpedia": 1,
       "kaliban": 1,
       "kanzlei-mieth": {
-        "": 1,
+        "*": 1,
         "/": 3,
         "/faq": 3,
         "/impressum": 3,
@@ -26638,7 +26635,7 @@
       "systemfehlr": 1,
       "sz-online": 1,
       "t-online": {
-        "": 1,
+        "*": 1,
         "email": 3,
         "freemail": 3,
         "gutscheine": 3,
@@ -26649,7 +26646,6 @@
         "tarife-und-produkte": 3,
         "telefonbuch": 3,
         "www": {
-          "": 1,
           "/preisvergleich": 3,
           "/shopping": 3
         }
@@ -37210,13 +37206,12 @@
       "twinge": 1,
       "twit": 1,
       "twitch": {
-        "": 1,
+        "*": 1,
         "app": 3,
         "dev": 3,
         "help": 3,
         "music": 3,
         "www": {
-          "": 1,
           "/": 3,
           "/directory": 3,
           "/store": 3

--- a/src/lib/background/domains/status/preset.js
+++ b/src/lib/background/domains/status/preset.js
@@ -69,9 +69,13 @@ function get({domain, url})
   if (treeNodes.length == hostParts.length)
   {
     // Does tree node define status of given path?
-    value = treeNode[pathname];
-    if (typeof value == "number")
-      return value;
+    if (pathname)
+    {
+      let [pathStart] = /^\/[^/]*/.exec(pathname);
+      value = treeNode[pathStart];
+      if (typeof value == "number")
+        return value;
+    }
 
     // Does tree node define a status for all paths?
     value = treeNode[""];

--- a/src/lib/background/domains/status/preset.js
+++ b/src/lib/background/domains/status/preset.js
@@ -9,7 +9,31 @@ const {
 const presets = require("../../../../data/domains");
 
 /**
- * Resolve flattr status for given URL or domain
+ * Retrieve only tree nodes which are relevant to the given host
+ * @param {string[]} hostParts - host parts (e.g. ["example", "com"])
+ * @return {any[]} tree nodes corresponding to given host parts
+ */
+function filterTree(hostParts)
+{
+  let treeNodes = [];
+  let tree = presets.status;
+  hostParts = hostParts.slice().reverse();
+
+  for (let hostPart of hostParts)
+  {
+    tree = tree[hostPart];
+    if (typeof tree == "undefined")
+      break;
+
+    treeNodes.push(tree);
+  }
+
+  treeNodes.reverse();
+  return treeNodes;
+}
+
+/**
+ * Resolve flattr status for given domain or URL
  * @param {Object} options
  * @param {string} [options.domain]
  * @param {string} [options.url]
@@ -17,6 +41,7 @@ const presets = require("../../../../data/domains");
  */
 function get({domain, url})
 {
+  // Determine what to search for
   let hostname = null;
   let pathname = null;
   if (url)
@@ -30,50 +55,40 @@ function get({domain, url})
   else
     return STATUS_UNDEFINED;
 
-  let hostParts = hostname.split(".").reverse();
+  let hostParts = hostname.split(".");
+  let treeNodes = filterTree(hostParts);
 
-  let tree = presets.status;
-  let value = null;
-  for (let hostPart of hostParts)
+  // Does most specific tree node only define a status? In that case
+  // we won't find anything more specific
+  let treeNode = treeNodes[0];
+  let value = treeNode;
+  if (typeof value == "number")
+    return value;
+
+  // Check tree node which exactly matches given host
+  if (treeNodes.length == hostParts.length)
   {
-    if (hostPart in tree)
-    {
-      // Check status for given domain
-      value = tree[hostPart];
-      if (typeof value == "number")
-        return value;
-
-      tree = value;
-      continue;
-    }
-
-    // Check status for all domains
-    value = tree["*"];
+    // Does tree node define status of given path?
+    value = treeNode[pathname];
     if (typeof value == "number")
       return value;
 
-    return STATUS_UNDEFINED;
-  }
-
-  if (pathname)
-  {
-    // Check status for given path
-    let [pathStart] = /^\/[^/]*/.exec(pathname);
-    value = tree[pathStart];
+    // Does tree node define a status for all paths?
+    value = treeNode[""];
     if (typeof value == "number")
       return value;
   }
 
-  // Check status for all paths
-  value = tree[""];
-  if (typeof value == "number")
-    return value;
+  // Check tree nodes from most to least specific
+  for (treeNode of treeNodes)
+  {
+    // Does tree node define a status for host and its subdomains?
+    value = treeNode["*"];
+    if (typeof value == "number")
+      return value;
+  }
 
-  // Check status for all domains
-  value = tree["*"];
-  if (typeof value == "number")
-    return value;
-
+  // We couldn't find any status
   return STATUS_UNDEFINED;
 }
 exports.get = get;

--- a/src/lib/background/domains/status/preset.js
+++ b/src/lib/background/domains/status/preset.js
@@ -17,18 +17,16 @@ function filterTree(hostParts)
 {
   let treeNodes = [];
   let tree = presets.status;
-  hostParts = hostParts.slice().reverse();
 
-  for (let hostPart of hostParts)
+  for (let hostPart, i = hostParts.length - 1; hostPart = hostParts[i]; i--)
   {
     tree = tree[hostPart];
     if (typeof tree == "undefined")
       break;
 
-    treeNodes.push(tree);
+    treeNodes.unshift(tree);
   }
 
-  treeNodes.reverse();
   return treeNodes;
 }
 

--- a/test/tests/domains.js
+++ b/test/tests/domains.js
@@ -5,7 +5,6 @@ const {expect} = require("chai");
 
 const {Window} = require("../mocks/window");
 const {
-  STATUS_BLOCKED: BLOCKED,
   STATUS_DISABLED: DISABLED,
   STATUS_ENABLED: ENABLED,
   STATUS_UNDEFINED: UNDEFINED
@@ -41,26 +40,21 @@ describe("Test domain checks", () =>
     },
     "../../src/data/domains": {
       status: {
-        com: {
-          "blocked-default": BLOCKED,
-          "enabled-default": ENABLED,
-          "foo": {
-            "": DISABLED,
-            "about": DISABLED,
-            "www": {
-              "*": DISABLED,
-              "/news": ENABLED
+        a1: {
+          "b1": {
+            "c1": 30,
+            "c2": {
+              "/foo": 31,
+              "": 32,
+              "*": 33
             },
-            "*": ENABLED
+            "/bar": 21,
+            "*": 22
           },
-          "bar": {
-            www: {
-              "": ENABLED,
-              "/": DISABLED,
-              "/about": DISABLED
-            }
-          },
-          "baz": BLOCKED
+          "*": 12
+        },
+        com: {
+          "enabled-default": ENABLED
         }
       }
     },
@@ -97,45 +91,27 @@ describe("Test domain checks", () =>
         });
   }
 
-  it("Should return the correct status for entity", () =>
-  {
-    let tests = [
-      ["enabled-default.com", ENABLED, ENABLED, UNDEFINED],
-      ["enabled-user.com", ENABLED, UNDEFINED, ENABLED],
-      ["disabled-default.com", DISABLED, UNDEFINED, UNDEFINED],
-      ["disabled-user.com", DISABLED, UNDEFINED, DISABLED],
-      ["foo.enabled-default.com", ENABLED, ENABLED, UNDEFINED],
-      ["foo.enabled-user.com", ENABLED, UNDEFINED, ENABLED],
-      ["foo.disabled-default.com", DISABLED, UNDEFINED, UNDEFINED],
-      ["foo.disabled-user.com", DISABLED, UNDEFINED, DISABLED],
-      ["blocked-default.com", BLOCKED, BLOCKED, UNDEFINED],
-      ["www.bar.com", ENABLED, ENABLED, UNDEFINED]
-    ];
+  it("Should use host value", () =>
+    checkEntity(["c1.b1.a1", 30, 30, UNDEFINED]));
 
-    return Promise.all(tests.map(checkEntity));
+  it("Should use pathname value", () =>
+  {
+    return Promise.all([
+      checkURL(["http://c2.b1.a1/foo", 31, 31, UNDEFINED]),
+      checkURL(["http://c2.b1.a1/bar", 32, 32, UNDEFINED])
+    ]);
   });
 
-  it("Should return the correct status for URL", () =>
-  {
-    let tests = [
-      ["http://enabled-default.com/", ENABLED, ENABLED, UNDEFINED],
-      [invalidUrl, BLOCKED, UNDEFINED, UNDEFINED],
-      ["http://foo.com/", DISABLED, DISABLED, UNDEFINED],
-      ["http://www.foo.com/", DISABLED, DISABLED, UNDEFINED],
-      ["http://vvv.foo.com/", ENABLED, ENABLED, UNDEFINED],
-      ["http://vvv.www.foo.com/", DISABLED, DISABLED, UNDEFINED],
-      ["http://about.foo.com/", DISABLED, DISABLED, UNDEFINED],
-      ["http://www.foo.com/news", ENABLED, ENABLED, UNDEFINED],
-      ["http://www.foo.com/news/", ENABLED, ENABLED, UNDEFINED],
-      ["http://bar.com/", DISABLED, UNDEFINED, UNDEFINED],
-      ["http://www.bar.com/", DISABLED, DISABLED, UNDEFINED],
-      ["http://www.bar.com/bar", ENABLED, ENABLED, UNDEFINED],
-      ["http://www.bar.com/about", DISABLED, DISABLED, UNDEFINED],
-      ["http://baz.com/", BLOCKED, BLOCKED, UNDEFINED]
-    ];
+  it("Should use \"\" value", () =>
+    checkEntity(["c2.b1.a1", 32, 32, UNDEFINED]));
 
-    return Promise.all(tests.map(checkURL));
-  });
+  it("Should use \"*\" value", () => checkEntity(["b1.a1", 22, 22, UNDEFINED]));
+
+  it("Should use parent host's \"*\" value", () =>
+    checkEntity(["d1.c2.b1.a1", 33, 33, UNDEFINED]));
+
+  it("Should return undefined if no matching host or parent host", () =>
+    checkEntity(["z1.y1.x1", DISABLED, UNDEFINED, UNDEFINED]));
 
   it("Should consider user changes", () =>
   {
@@ -146,7 +122,7 @@ describe("Test domain checks", () =>
         .then(() => domains.setEntityStatus(disabled, DISABLED))
         .then(() => checkEntity([disabled, DISABLED, UNDEFINED, DISABLED]));
 
-    let enabled = "enabled-default.com";
+    const enabled = "enabled-default.com";
     let testEnabled = checkEntity([enabled, ENABLED, ENABLED, UNDEFINED])
         .then(() => domains.setEntityStatus(enabled, DISABLED))
         .then(() => checkEntity([enabled, DISABLED, ENABLED, DISABLED]))

--- a/test/tests/domains.js
+++ b/test/tests/domains.js
@@ -45,6 +45,7 @@ describe("Test domain checks", () =>
             "c1": 30,
             "c2": {
               "/foo": 31,
+              "/foo/bar": 40,
               "": 32,
               "*": 33
             },
@@ -99,6 +100,16 @@ describe("Test domain checks", () =>
     return Promise.all([
       checkURL(["http://c2.b1.a1/foo", 31, 31, UNDEFINED]),
       checkURL(["http://c2.b1.a1/bar", 32, 32, UNDEFINED])
+    ]);
+  });
+
+  it("Should match only first part of pathname", () =>
+  {
+    return Promise.all([
+      checkURL(["http://c2.b1.a1/", 32, 32, UNDEFINED]),
+      checkURL(["http://c2.b1.a1/foo", 31, 31, UNDEFINED]),
+      checkURL(["http://c2.b1.a1/foobar", 32, 32, UNDEFINED]),
+      checkURL(["http://c2.b1.a1/foo/bar", 31, 31, UNDEFINED])
     ]);
   });
 


### PR DESCRIPTION
This PR contains the following changes:
- Rewrote `get()` function in lib/background/status/presets.js: Instead of going through the tree from least to most specific part of the host (i.e. "com", "example", "www") and continuously overriding the result, we're now going from most to least specific (i.e. "www", "example", "com") and use the first result we encounter.
- Introduced `filterTree()` function to prepare the status structure for the new approach.
- Updated domains.json to use correct key so that statuses also apply to subdomains.
- Replaced existing tests to check each part of the functionality.