### PR TITLE
Noissue - Added version number to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flattr-extension",
-  "private": true,
+  "version": "0.6.0",
   "scripts": {
     "build": "gulp build",
     "bundle": "gulp bundle",


### PR DESCRIPTION
IIRC the reason why we set `private: true` was to prevent accidental publication but since we've made the extension open source now, there's no need for it anymore. Furthermore, by setting a version number we can allow others to reuse various components by adding the repo as a dependency.