### PR TITLE
Noissue - Updated indexeddbshim dependency to 4.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "gulp-sourcemaps": "^2.4.1",
     "gulp-svg2png": "^2.0.2",
     "gulp-zip": "^3.2.0",
-    "indexeddbshim": "axemclion/IndexedDBShim#d50bc25db6",
+    "indexeddbshim": "^4.1.0",
     "jsdom": "^9.12.0",
     "map-stream": "0.0.6",
     "minimist": "^1.2.0",

--- a/test/mocks/indexeddb.js
+++ b/test/mocks/indexeddb.js
@@ -2,4 +2,4 @@
 
 const setGlobalVars = require("indexeddbshim");
 
-setGlobalVars(module.exports, {sqlBusyTimeout: 100});
+setGlobalVars(module.exports, {checkOrigin: false, sqlBusyTimeout: 100});


### PR DESCRIPTION
It turns out that one of indexeddbshim's dependencies (w3c/pywebsocket) no longer exist which causes `npm install` to fail. Since it now supports the `checkOrigin` flag, however, we should be able to rely on its published version again.

I was having some trouble getting test/tests/update.js to work though because it's neither triggering the onerror nor onsuccess listeners. Since those particular tests don't need a database anyway, I decided to remove the dependency on indexeddbhsim there.