### PR TITLE
Add Dat protocol support

### DIFF
--- a/src/lib/background/index.js
+++ b/src/lib/background/index.js
@@ -220,7 +220,7 @@ chrome.webRequest.onHeadersReceived.addListener(
 
     record(tabId, "page-loaded", statusCode);
   },
-  {urls: ["http://*/*", "https://*/*"]}
+  {urls: ["http://*/*", "https://*/*", "dat://*/*"]}
 );
 
 on("authentication-changed", (isAuthenticated) =>

--- a/src/lib/common/utils.js
+++ b/src/lib/common/utils.js
@@ -54,6 +54,9 @@ exports.getCurrentTab = getCurrentTab;
 function normalizeURL(url)
 {
   url = new URL(url);
+  if (url.protocol == 'dat:')
+    url.protocol = 'http:'
+
   if (!/^https?:$/.test(url.protocol))
     throw new URIError("URL has invalid protocol");
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -25,7 +25,11 @@
   },
   "content_scripts": [
     {
-      "matches": ["http://*/*", "https://*/*"],
+      "matches": [
+        "https://*/*",
+        "http://*/*",
+        "dat://*/*"
+      ],
       "js": ["lib/content/index.js"],
       "run_at": "document_start"
     }
@@ -45,6 +49,7 @@
   "permissions": [
     "http://*/*",
     "https://*/*",
+    "dat://*/*",
     "alarms",
     "history",
     "idle",


### PR DESCRIPTION
Dat is peer-to-peer HTTP. Mozilla is working on bringing distributed web protocols  natively into Firefox (libdweb), and the Cliqz browser (a Firefox fork) have already shipped beta builds that support the protocol out of the box.

This implementation assumes that Dat enabled archives are also available on HTTP and simply normalize Dat URLs to submit their HTTP equivalent. Non-DNS based Dat archives will be discarded by the existing TLD normalization.

Turns:
dat://beakerbrowser.com/

Into:
http://beakerbrowser.com/
