### PR TITLE
Relink “dashboard” to /dashboard/contributor

### DIFF
--- a/src/lib/ui/components/flattr-popup.js
+++ b/src/lib/ui/components/flattr-popup.js
@@ -111,7 +111,7 @@ class FlattrPopup extends VirtualElement
               "a.icon.icon-flattr-alt",
               {
                 dataset: {click: "open"},
-                href: `${API_BASE_WEB}/signin`
+                href: `${API_BASE_WEB}/dashboard/contributor`
               },
               i18n.get("popup_footer_account")
             )


### PR DESCRIPTION
/signin defaults to the creator dashboard, but users will want to go to their contributor dashboard in the context of the extension pop-out window.